### PR TITLE
`snake_case` should be persisted in instance variable

### DIFF
--- a/lib/hadoop_metrics2/api.rb
+++ b/lib/hadoop_metrics2/api.rb
@@ -8,7 +8,7 @@ module HadoopMetrics2
       @endpoint = "#{host}:#{port}"
       @metrics_endpoint = master ?
         URI("http://#{@endpoint}/ws/v1/cluster/metrics") : URI("http://#{@endpoint}/ws/v1/node/info")
-      snake_case = opts.has_key?(:snake_case) ? opts[:snake_case] : true
+      @snake_case = opts.has_key?(:snake_case) ? opts[:snake_case] : true
       @name = opts[:name] || host
       @metrics_cache = nil
       @scheduler_cache = nil


### PR DESCRIPTION
The option of `:snake_case` should be persist in instance variable to use it later in `HadoopMetrics2::API#disable_snake_case`.

https://github.com/ryukobayashi/hadoop-metrics2/blob/598e9d8ab672c55fb6ffd3d12403f92f37761f89/lib/hadoop_metrics2/api.rb#L138
