### PR TITLE
Remove a unused variable named `column`

### DIFF
--- a/lib/hadoop_metrics2/node_manager.rb
+++ b/lib/hadoop_metrics2/node_manager.rb
@@ -11,15 +11,7 @@ module HadoopMetrics2
     end
 
     def application(opts = {})
-      column = get_column(opts)
-      column = HadoopMetrics2.to_snake_case(column) if @snake_case
       metrics(get_force(opts))['nodeInfo']
-    end
-
-    private
-
-    def get_column(opts)
-      opts[:column]
     end
   end
 end

--- a/lib/hadoop_metrics2/resource_manager.rb
+++ b/lib/hadoop_metrics2/resource_manager.rb
@@ -12,8 +12,6 @@ module HadoopMetrics2
     end
 
     def application(opts = {})
-      column = get_column(opts)
-      column = HadoopMetrics2.to_snake_case(column) if @snake_case
       metrics(get_force(opts))['clusterMetrics']
     end
 
@@ -28,12 +26,6 @@ module HadoopMetrics2
         each_apps[name] += target['numActiveApps']
       }
       each_apps
-    end
-
-    private
-
-    def get_column(opts)
-      opts[:column]
     end
   end
 end


### PR DESCRIPTION
`HadoopMetrics2.to_snake_case(column)` will raise `NoMethodError` if `get_column()` returns `nil` and `@snake_case` is `true`. I just removed a variable of `column` and associated helper method since it is no longer used.
