### PR TITLE
Skip empty GC information

### DIFF
--- a/lib/hadoop_metrics2/api.rb
+++ b/lib/hadoop_metrics2/api.rb
@@ -43,9 +43,7 @@ module HadoopMetrics2
 
     def gc
       disable_snake_case {
-        result = query_jmx('java.lang:type=GarbageCollector,name=*').map { |jmx_gc_info|
-          return nil if jmx_gc_info['LastGcInfo'].nil?
-
+        query_jmx('java.lang:type=GarbageCollector,name=*').reject { |jmx_gc_info| jmx_gc_info['LastGcInfo'].nil? }.map { |jmx_gc_info|
           gc_info = {'type' => GCNameMap[jmx_gc_info['Name']]}
           gc_info['estimated_time'] = jmx_gc_info['CollectionTime']
           gc_info['count'] = jmx_gc_info['CollectionCount']


### PR DESCRIPTION
In our environment, `LastGcInfo` is typically empty as the list retains entries where no GC has happened. The current implementation of `gc` method returns `nil` in that case.

This is a demo.

```
irb(main):017:0> def mofu(arr)
irb(main):018:1>   result = arr.map { |x|
irb(main):019:2*     return nil if x.nil?
irb(main):020:2>     x + 1
irb(main):021:2>   }
irb(main):022:1> end
=> :mofu
irb(main):023:0> mofu([1, 2, 3])
=> [2, 3, 4]
irb(main):024:0> mofu([1, nil, 3])
=> nil
```

The new information should return the elements of valid entries.

```
irb(main):043:0> def mofu(arr)
irb(main):044:1>   arr.reject { |x| x.nil? }.map { |x|
irb(main):045:2*     x + 1
irb(main):046:2>   }
irb(main):047:1> end
=> :mofu
irb(main):048:0> mofu([1, 2, 3])
=> [2, 3, 4]
irb(main):049:0> mofu([1, nil, 3])
=> [2, 4]
```